### PR TITLE
fix graceful shutdown

### DIFF
--- a/src/shutdown_signal.rs
+++ b/src/shutdown_signal.rs
@@ -1,0 +1,28 @@
+use tokio::signal;
+
+// adopted from https://github.com/tokio-rs/axum/blob/main/examples/graceful-shutdown/src/main.rs
+pub(crate) async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    log::info!("signal received, starting graceful shutdown");
+}


### PR DESCRIPTION
I'm not 100% sure if calling stop_io is enough to gracefully shutdown deltachat core.
